### PR TITLE
Add explicit bool cast for C++11, fix #16

### DIFF
--- a/include/hpp/util/assertion.hh
+++ b/include/hpp/util/assertion.hh
@@ -33,7 +33,7 @@ namespace hpp
 # ifdef HPP_ENABLE_ASSERTIONS
 #  define HPP_ASSERT(CONDITION)					\
   do {								\
-    bool _x = (CONDITION);					\
+    bool _x = static_cast<bool>(CONDITION);					\
     if (!_x)							\
       HPP_THROW_EXCEPTION					\
 	(::hpp::AssertionError,					\


### PR DESCRIPTION
Add explicit cast in the definition of HPP_ASSERT because C++11 does not
accept implicit conversion from shared_ptr to bool.