### PR TITLE
FIX: force system_clock

### DIFF
--- a/include/hpp/util/timer.hh
+++ b/include/hpp/util/timer.hh
@@ -37,7 +37,7 @@ namespace hpp {
 namespace debug {
 class HPP_UTIL_DLLAPI Timer {
  public:
-  typedef std::chrono::system_clock clock_type;
+  typedef std::chrono::steady_clock clock_type;
   typedef clock_type::time_point time_point;
   typedef std::chrono::duration<double> duration_type;
 

--- a/include/hpp/util/timer.hh
+++ b/include/hpp/util/timer.hh
@@ -37,7 +37,7 @@ namespace hpp {
 namespace debug {
 class HPP_UTIL_DLLAPI Timer {
  public:
-  typedef std::chrono::high_resolution_clock clock_type;
+  typedef std::chrono::system_clock clock_type;
   typedef clock_type::time_point time_point;
   typedef std::chrono::duration<double> duration_type;
 
@@ -101,7 +101,7 @@ class HPP_UTIL_DLLAPI TimeCounter {
     TimeCounter& tc;
   };
 
-  typedef std::chrono::high_resolution_clock clock_type;
+  typedef std::chrono::system_clock clock_type;
   typedef clock_type::time_point time_point;
   typedef std::chrono::duration<double> duration_type;
 

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -60,7 +60,11 @@ const Timer::time_point& Timer::getStop() const { return end_; }
 double Timer::duration() const { return duration_type(end_ - start_).count(); }
 
 std::ostream& Timer::print(std::ostream& o) const {
-  auto time = clock_type::to_time_t(start_);
+  auto time = system_clock::to_time_t(
+      system_clock::now()
+      + duration_cast<system_clock::duration>(start_ - clock_type::now())
+    );
+
   return o << "timer started at "
            << std::put_time(std::localtime(&time), "%F %T")
            << " and elapsed time "

--- a/src/timer.cc
+++ b/src/timer.cc
@@ -61,9 +61,8 @@ double Timer::duration() const { return duration_type(end_ - start_).count(); }
 
 std::ostream& Timer::print(std::ostream& o) const {
   auto time = system_clock::to_time_t(
-      system_clock::now()
-      + duration_cast<system_clock::duration>(start_ - clock_type::now())
-    );
+      system_clock::now() +
+      duration_cast<system_clock::duration>(start_ - clock_type::now()));
 
   return o << "timer started at "
            << std::put_time(std::localtime(&time), "%F %T")


### PR DESCRIPTION
As motioned [here](https://stackoverflow.com/questions/13263277/difference-between-stdsystem-clock-and-stdsteady-clock), `high_resolution_clock` is an alias for either `system_clock` or `steady_clock`, but in the code of hpp_util, there is a use of the method `to_time_t` which is a method only of `system_clock`, so we should force `clock_type` to alias `system_clock`.