### PR TITLE
Enable toggling logs dynamically

### DIFF
--- a/include/hpp/util/debug.hh
+++ b/include/hpp/util/debug.hh
@@ -89,6 +89,32 @@ HPP_UTIL_DLLAPI std::string getPrefix(const std::string& packageName);
 HPP_UTIL_DLLAPI std::string getFilename(const std::string& filename,
                                         const std::string& packageName);
 
+
+namespace verbosityLevel {
+  constexpr int none = 0;
+  constexpr int error = 10;
+  constexpr int warning = 20;
+  constexpr int notice = 30;
+  constexpr int info = 40;
+  constexpr int benchmark = -1;
+}
+
+/// \brief Get the verbosity level.
+HPP_UTIL_DLLAPI int getVerbosityLevel();
+
+/// \brief Set the verbosity level.
+HPP_UTIL_DLLAPI void setVerbosityLevel(int level);
+
+HPP_UTIL_DLLAPI bool isBenchmarkEnabled();
+
+HPP_UTIL_DLLAPI void enableBenchmark(bool enable);
+
+inline bool isChannelEnabled(int channel) {
+  if (channel == verbosityLevel::benchmark)
+    return isBenchmarkEnabled();
+  return getVerbosityLevel() >= channel;
+}
+
 /// \brief Debugging output.
 ///
 /// Represents a debugging output, i.e. an output stream
@@ -237,13 +263,15 @@ extern HPP_UTIL_DLLAPI Logging logging;
 /// \param channel one of \em error, \em warning, \em notice, \em info or \em
 /// benchmark. \param data a statement that can be \c << to a \c
 /// std::stringstream.
-#define hppDout(channel, data)                                            \
-  do {                                                                    \
-    using namespace hpp;                                                  \
-    using namespace ::hpp::debug;                                         \
-    std::stringstream __ss;                                               \
-    __ss << data << iendl;                                                \
-    logging.channel.write(__FILE__, __LINE__, __PRETTY_FUNCTION__, __ss); \
+#define hppDout(channel, data)                                              \
+  do {                                                                      \
+    using namespace hpp;                                                    \
+    using namespace ::hpp::debug;                                           \
+    if (isChannelEnabled(verbosityLevel::channel)) {                        \
+      std::stringstream __ss;                                               \
+      __ss << data << iendl;                                                \
+      logging.channel.write(__FILE__, __LINE__, __PRETTY_FUNCTION__, __ss); \
+    }                                                                       \
   } while (0)
 
 /// \brief Write \c data to \c channel and exit the program.

--- a/include/hpp/util/debug.hh
+++ b/include/hpp/util/debug.hh
@@ -89,15 +89,14 @@ HPP_UTIL_DLLAPI std::string getPrefix(const std::string& packageName);
 HPP_UTIL_DLLAPI std::string getFilename(const std::string& filename,
                                         const std::string& packageName);
 
-
 namespace verbosityLevel {
-  constexpr int none = 0;
-  constexpr int error = 10;
-  constexpr int warning = 20;
-  constexpr int notice = 30;
-  constexpr int info = 40;
-  constexpr int benchmark = -1;
-}
+constexpr int none = 0;
+constexpr int error = 10;
+constexpr int warning = 20;
+constexpr int notice = 30;
+constexpr int info = 40;
+constexpr int benchmark = -1;
+}  // namespace verbosityLevel
 
 /// \brief Get the verbosity level.
 HPP_UTIL_DLLAPI int getVerbosityLevel();
@@ -110,8 +109,7 @@ HPP_UTIL_DLLAPI bool isBenchmarkEnabled();
 HPP_UTIL_DLLAPI void enableBenchmark(bool enable);
 
 inline bool isChannelEnabled(int channel) {
-  if (channel == verbosityLevel::benchmark)
-    return isBenchmarkEnabled();
+  if (channel == verbosityLevel::benchmark) return isBenchmarkEnabled();
   return getVerbosityLevel() >= channel;
 }
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -55,6 +55,10 @@ namespace debug {
 /// directory.
 static const char* ENV_LOGGINGDIR = "HPP_LOGGINGDIR";
 
+static int verbosity = static_cast<int>(verbosityLevel::error);
+
+static int benchmarkEnabled = false;
+
 namespace {
 HPP_UTIL_LOCAL void makeDirectory(const std::string& filename) {
   using namespace boost::filesystem;
@@ -94,6 +98,14 @@ std::string getFilename(const std::string& filename,
   makeDirectory(res);
   return res;
 }
+
+int getVerbosityLevel() { return verbosity; }
+
+void setVerbosityLevel(int level) { verbosity = level; }
+
+bool isBenchmarkEnabled() { return benchmarkEnabled; }
+
+void enableBenchmark(bool enable) { benchmarkEnabled = enable; }
 
 Output::Output() {}
 

--- a/src/debug.cc
+++ b/src/debug.cc
@@ -28,8 +28,10 @@
 #include "hpp/util/debug.hh"
 
 #include <boost/filesystem.hpp>  // Need C++ 17 to remove this.
+#include <chrono>
 #include <cstdlib>
 #include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <sstream>
 
@@ -113,7 +115,17 @@ Output::~Output() {}
 
 std::ostream& Output::writePrefix(std::ostream& stream, const Channel& channel,
                                   char const* file, int line, char const*) {
-  stream << channel.label() << ':' << file << ':' << line << ": ";
+  using std::chrono::system_clock;
+  system_clock::time_point now_point = system_clock::now();
+  const std::time_t now = system_clock::to_time_t(now_point);
+  const auto millis{std::chrono::duration_cast<std::chrono::milliseconds>(
+                        now_point.time_since_epoch())
+                        .count() %
+                    1000};
+
+  stream << std::put_time(std::localtime(&now), "[%F %T") << "." << std::setw(3)
+         << std::setfill('0') << millis << ']' << channel.label() << ':' << file
+         << ':' << line << ": ";
   return stream;
 }
 


### PR DESCRIPTION
In this PR, together with an upcoming PR, I enable toggling dynamically logs using the verbosity level. HPP_DEBUG preprocessor variable is still honored.

Additionally, I also added the time as a prefix to the logs. It looks like
```
[2023-07-10 21:00:19.924]NOTICE:/opt/hpp/src/hpp-core/src/path-validation/discretized.cc:58: path validation, reverse : 0
```