### PR TITLE
remove deprecated stuff

### DIFF
--- a/src/debug.cc
+++ b/src/debug.cc
@@ -67,10 +67,7 @@ HPP_UTIL_LOCAL void makeDirectory(const std::string& filename) {
   using namespace boost::filesystem;
   path pathname(filename);
 
-  // FIXME: Boost 1.34.1 does not support the non-obsolete
-  // equivalent of branch_path, parent_path, so bear with
-  // it for now.
-  std::string dirname = pathname.branch_path().string();
+  std::string dirname = pathname.parent_path().string();
 
   boost::filesystem::create_directories(dirname);
 }

--- a/src/factories/sequence.cc
+++ b/src/factories/sequence.cc
@@ -45,7 +45,7 @@ namespace {
 #define TIXML_SSCANF sscanf
 #endif
 
-struct StringIsEmpty : public std::unary_function<std::string, bool> {
+struct StringIsEmpty {
   bool operator()(std::string s) const { return s.empty(); }
 };
 


### PR DESCRIPTION
std::unary_function is useless and was removed in C++17.
Boost 1.34 is no longer relevant.
fix #70 