### PR TITLE
fix C++20 compat

### DIFF
--- a/include/hpp/util/serialization.hh
+++ b/include/hpp/util/serialization.hh
@@ -209,9 +209,8 @@ class archive_ptr_holder {
     ar << make_nvp("nrequires", size);
     typedef std::pair<std::string, std::string> string_pair;
     for (auto it : ptrs_) {
-      string_pair
-        requires(it.first, it.second->classid);
-      ar << make_nvp("requires", requires);
+      string_pair required(it.first, it.second->classid);
+      ar << make_nvp("requires", required);
     }
   }
   template <typename Archive,


### PR DESCRIPTION
```cpp
In file included from /ws/src/hpp-util/tests/serialization.cc:31:
/ws/src/hpp-util/include/hpp/util/serialization.hh:213:9: warning: identifier ‘requires’ is a keyword in C++20 [-Wc++20-compat]
  213 |         requires(it.first, it.second->classid);
      |         ^~~~~~~~
```